### PR TITLE
Remove unused NodeHeader::unlock_optimistic method

### DIFF
--- a/btree/src/node.rs
+++ b/btree/src/node.rs
@@ -95,10 +95,6 @@ impl NodeHeader {
     pub fn lock_optimistic(&self) -> Result<LockInfo, ()> {
         self.lock.lock_optimistic()
     }
-    pub fn unlock_optimistic(&self) {
-        self.lock.unlock_exclusive();
-    }
-
     pub fn validate_optimistic(&self, version: LockInfo) -> Result<(), ()> {
         if self.lock.validate_optimistic_read(version) {
             Ok(())


### PR DESCRIPTION
## Summary
- delete `NodeHeader::unlock_optimistic` since it wasn't referenced

## Testing
- `cargo test --no-run` *(fails: failed to get `fxhash` as a dependency)*