### PR TITLE
Add edge case tests for parallel_scan

### DIFF
--- a/btree/src/bulk_operations/parallel_scan.rs
+++ b/btree/src/bulk_operations/parallel_scan.rs
@@ -406,4 +406,46 @@ mod test {
             );
         }
     }
+
+    #[qsbr_test]
+    fn it_parallel_scans_single_leaf() {
+        let num_rows = ORDER - 1;
+        let tree = make_tree(num_rows);
+        let results = scan_parallel(
+            Some(OwnedThinArc::new(0).share()),
+            Some(OwnedThinArc::new(num_rows).share()),
+            |_v: &usize| true,
+            &tree,
+        );
+
+        let expected_values: Vec<usize> = (0..num_rows).collect();
+
+        for (actual, expected) in results.into_iter().zip(expected_values) {
+            assert_eq!(
+                actual, expected,
+                "The collected results do not match the expected values.",
+            );
+        }
+    }
+
+    #[qsbr_test]
+    fn it_parallel_scans_small_tree() {
+        let num_rows = ORDER * 2;
+        let tree = make_tree(num_rows);
+        let results = scan_parallel(
+            Some(OwnedThinArc::new(0).share()),
+            Some(OwnedThinArc::new(num_rows).share()),
+            |_v: &usize| true,
+            &tree,
+        );
+
+        let expected_values: Vec<usize> = (0..num_rows).collect();
+
+        for (actual, expected) in results.into_iter().zip(expected_values) {
+            assert_eq!(
+                actual, expected,
+                "The collected results do not match the expected values.",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- verify `scan_parallel` works with a single-leaf tree
- verify it handles a small tree that can't be split into all ranges

## Testing
- `cargo test --workspace -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_683d1d0844948330ad849c3369fdc69d