### PR TITLE
Change parallel scan to use range

### DIFF
--- a/btree/benches/bulk_ops.rs
+++ b/btree/benches/bulk_ops.rs
@@ -117,8 +117,10 @@ fn scan_parallel_benchmark(c: &mut BenchmarkGroup<'_, criterion::measurement::Wa
                 for _ in 0..iters {
                     let start_instant = std::time::Instant::now();
                     // tree.scan_parallel is a method on BTree that calls the actual parallel scan logic
-                    let _result =
-                        tree.scan_parallel(start_key.share(), end_key.share(), &predicate);
+                    let _result = tree.scan_parallel(
+                        start_key.share()..end_key.share(),
+                        &predicate,
+                    );
                     sum += start_instant.elapsed();
                 }
 


### PR DESCRIPTION
## Summary
- update parallel scan implementation to work with `RangeBounds`
- handle inclusive and exclusive bounds in leaf and parallel cases
- add tests for inclusive end and unbounded ranges

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683d1cd7988883308c4ef8adcb5ccce1