### PR TITLE
Add background garbage collection option to QSBR

### DIFF
--- a/qsbr/src/lib.rs
+++ b/qsbr/src/lib.rs
@@ -1,13 +1,30 @@
 use fxhash::FxHashSet;
 use rayon::{ThreadPool, ThreadPoolBuilder};
 
-use std::sync::Mutex;
+use std::sync::{Arc, Condvar, Mutex};
 use std::{collections::VecDeque, sync::OnceLock};
 
-/// A memory reclaimer using intervals to defer resource reclamation until all threads are quiescent
-/// Threads must register before using the reclaimer
+/// A memory reclaimer using intervals to defer resource reclamation until all threads are quiescent.
+/// Threads must register before using the reclaimer.
+///
+/// ## Background garbage collection
+///
+/// When constructed with [`MemoryReclaimer::new_with_background`], a dedicated
+/// worker thread is spawned to run deferred callbacks. The worker sleeps on a
+/// [`Condvar`] and wakes whenever callbacks become available. Callbacks waiting
+/// to be reclaimed are stored in `ready_callbacks`, a queue protected by a
+/// mutex. The worker drains this queue and executes the callbacks outside of the
+/// lock so that application threads are not blocked while reclamation occurs.
+///
+/// At the end of each interval [`dispatch_callbacks`] moves callbacks into the
+/// shared queue and notifies the worker. If the queue was not empty beforehand
+/// the worker has fallen behind. The thread that finishes the interval then
+/// drains the entire queue and executes the callbacks itself, ensuring progress
+/// even under heavy load.
 pub struct MemoryReclaimer {
-    inner: Mutex<MemoryReclaimerInner>,
+    inner: Arc<Mutex<MemoryReclaimerInner>>,
+    condvar: Arc<Condvar>,
+    background_thread: Option<std::thread::JoinHandle<()>>,
 }
 
 type ThreadId = u64;
@@ -29,11 +46,14 @@ struct MemoryReclaimerInner {
     /// Callbacks accumulated in the previous interval; these are executed
     /// when an interval completes
     previous_interval_callbacks: VecDeque<Box<dyn FnOnce() + Send>>,
+    /// Callbacks ready for execution by the background thread
+    ready_callbacks: VecDeque<Box<dyn FnOnce() + Send>>,
     /// Threads that have registered with the reclaimer
     registered_threads: FxHashSet<ThreadId>,
     /// Registered threads that have signaled quiescence in the current interval
     quiesced_threads: FxHashSet<ThreadId>,
 }
+
 
 #[cfg(not(feature = "shuttle"))]
 std::thread_local! {
@@ -61,13 +81,50 @@ struct ThreadState {
 impl MemoryReclaimer {
     fn new() -> Self {
         Self {
-            inner: Mutex::new(MemoryReclaimerInner {
+            inner: Arc::new(Mutex::new(MemoryReclaimerInner {
                 current_interval_callbacks: VecDeque::new(),
                 previous_interval_callbacks: VecDeque::new(),
+                ready_callbacks: VecDeque::new(),
                 registered_threads: FxHashSet::default(),
                 quiesced_threads: FxHashSet::default(),
-            }),
+            })),
+            condvar: Arc::new(Condvar::new()),
+            background_thread: None,
         }
+    }
+
+    /// Creates a reclaimer with a background garbage collection thread.
+    pub fn new_with_background() -> Self {
+        let mut r = Self {
+            inner: Arc::new(Mutex::new(MemoryReclaimerInner {
+                current_interval_callbacks: VecDeque::new(),
+                previous_interval_callbacks: VecDeque::new(),
+                ready_callbacks: VecDeque::new(),
+                registered_threads: FxHashSet::default(),
+                quiesced_threads: FxHashSet::default(),
+            })),
+            condvar: Arc::new(Condvar::new()),
+            background_thread: None,
+        };
+        r.start_background_thread();
+        r
+    }
+
+    fn start_background_thread(&mut self) {
+        let inner = Arc::clone(&self.inner);
+        let condvar = Arc::clone(&self.condvar);
+        self.background_thread = Some(std::thread::spawn(move || loop {
+            let callbacks = {
+                let mut inner = inner.lock().unwrap();
+                while inner.ready_callbacks.is_empty() {
+                    inner = condvar.wait(inner).unwrap();
+                }
+                std::mem::take(&mut inner.ready_callbacks)
+            };
+            for cb in callbacks {
+                cb();
+            }
+        }));
     }
 
     /// Registers the current thread
@@ -124,7 +181,7 @@ impl MemoryReclaimer {
         inner.quiesced_threads.insert(thread_id);
 
         // Attempt to complete the interval if all registered threads have quiesced.
-        Self::complete_interval_if_possible(&mut inner);
+        self.complete_interval_if_possible(&mut inner);
     }
 
 
@@ -160,7 +217,7 @@ impl MemoryReclaimer {
                 // Attempt to complete the interval if possible.
                 // (If there are no remaining registered threads, or if all remaining have quiesced,
                 // the interval is complete.)
-                Self::complete_interval_if_possible(&mut inner);
+                self.complete_interval_if_possible(&mut inner);
 
                 // Remove the thread from registration (it will no longer participate in future intervals).
                 inner.registered_threads.remove(&thread_id);
@@ -171,23 +228,44 @@ impl MemoryReclaimer {
     }
 
     /// Completes the interval if all threads are quiescent
-    fn complete_interval_if_possible(inner: &mut MemoryReclaimerInner) {
+    fn complete_interval_if_possible(&self, inner: &mut MemoryReclaimerInner) {
         if inner.quiesced_threads.len() == inner.registered_threads.len() {
-            // Always execute callbacks from the previous interval.
-            while let Some(callback) = inner.previous_interval_callbacks.pop_front() {
-                callback();
-            }
-            // If there's only a single thread (or none) in the interval, free the current interval's garbage
-            // immediately. Otherwise, promote the current interval's callbacks to be freed in the next interval.
+            let mut ready = std::mem::take(&mut inner.previous_interval_callbacks);
             if inner.registered_threads.len() <= 1 {
-                while let Some(callback) = inner.current_interval_callbacks.pop_front() {
-                    callback();
-                }
+                ready.append(&mut inner.current_interval_callbacks);
             } else {
                 inner.previous_interval_callbacks =
                     std::mem::take(&mut inner.current_interval_callbacks);
             }
             inner.quiesced_threads.clear();
+            self.dispatch_callbacks(ready);
+        }
+    }
+
+    fn dispatch_callbacks(&self, mut callbacks: VecDeque<Box<dyn FnOnce() + Send>>) {
+        if let Some(_handle) = &self.background_thread {
+            let mut run_now = false;
+            {
+                let mut inner = self.inner.lock().unwrap();
+                if inner.ready_callbacks.is_empty() {
+                    inner.ready_callbacks.append(&mut callbacks);
+                } else {
+                    inner.ready_callbacks.append(&mut callbacks);
+                    callbacks = std::mem::take(&mut inner.ready_callbacks);
+                    run_now = true;
+                }
+            }
+            if run_now {
+                for cb in callbacks {
+                    cb();
+                }
+            } else {
+                self.condvar.notify_one();
+            }
+        } else {
+            for cb in callbacks {
+                cb();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- support an optional background garbage collector in `qsbr`
- spawn a sleeping GC worker that wakes when notified
- detect backlog via an empty queue check and let producers assist with reclamation
- document the design of background GC

## Testing
- `cargo test -p qsbr -- --nocapture`
- `cargo check --workspace`


------
https://chatgpt.com/codex/tasks/task_e_683d220040a08330a1ace0e3598984cc