### PR TITLE
Rename jittered lock methods to with_backoff

### DIFF
--- a/btree/src/coalescing.rs
+++ b/btree/src/coalescing.rs
@@ -33,7 +33,7 @@ pub fn coalesce_or_redistribute_leaf_node<K: BTreeKey + ?Sized, V: BTreeValue + 
     let (full_leaf_node, node_position) =
         locked_parent.get_neighbor_of_underfull_leaf(locked_underfull_leaf);
 
-    let locked_full_leaf = full_leaf_node.lock_exclusive_jittered();
+    let locked_full_leaf = full_leaf_node.lock_exclusive_with_backoff();
 
     if locked_underfull_leaf.num_keys() + locked_full_leaf.num_keys() <= MAX_KEYS_PER_NODE {
         match node_position {

--- a/btree/src/hybrid_latch.rs
+++ b/btree/src/hybrid_latch.rs
@@ -165,15 +165,15 @@ impl HybridLatch {
         self.version.load(Ordering::Acquire)
     }
 
-    pub fn lock_exclusive_jittered(&self) {
+    pub fn lock_exclusive_with_backoff(&self) {
         debug_assert!(!self.is_retired());
         if self.rw_lock.try_lock_exclusive() {
             return;
         }
-        jittered_retry(&self.rw_lock);
+        retry_with_backoff(&self.rw_lock);
     }
 
-    pub fn lock_exclusive_if_not_retired_jittered(&self) -> Result<(), LockError> {
+    pub fn lock_exclusive_if_not_retired_with_backoff(&self) -> Result<(), LockError> {
         if self.rw_lock.try_lock_exclusive() {
             if self.is_retired() {
                 self.rw_lock.unlock_exclusive();
@@ -181,7 +181,7 @@ impl HybridLatch {
             }
             return Ok(());
         }
-        jittered_retry(&self.rw_lock);
+        retry_with_backoff(&self.rw_lock);
         if self.is_retired() {
             self.rw_lock.unlock_exclusive();
             return Err(LockError::Retired);
@@ -210,7 +210,7 @@ impl HybridLatch {
 
 /// Timed lock attempts with yields between retries to break deadlocks.
 /// Timeout escalates from 1us to 1ms to avoid starvation.
-fn jittered_retry(lock: &RwLock) {
+fn retry_with_backoff(lock: &RwLock) {
     let mut timeout_us: u64 = 10;
     loop {
         if lock.try_lock_exclusive_for(Duration::from_micros(timeout_us)) {

--- a/btree/src/node.rs
+++ b/btree/src/node.rs
@@ -57,11 +57,11 @@ impl NodeHeader {
     pub fn lock_exclusive_if_not_retired(&self) -> Result<(), LockError> {
         self.lock.lock_exclusive_if_not_retired()
     }
-    pub fn lock_exclusive_jittered(&self) {
-        self.lock.lock_exclusive_jittered();
+    pub fn lock_exclusive_with_backoff(&self) {
+        self.lock.lock_exclusive_with_backoff();
     }
-    pub fn lock_exclusive_if_not_retired_jittered(&self) -> Result<(), LockError> {
-        self.lock.lock_exclusive_if_not_retired_jittered()
+    pub fn lock_exclusive_if_not_retired_with_backoff(&self) -> Result<(), LockError> {
+        self.lock.lock_exclusive_if_not_retired_with_backoff()
     }
     pub fn is_locked_exclusive(&self) -> bool {
         self.lock.is_locked_exclusive()

--- a/btree/src/pointers/node_ref.rs
+++ b/btree/src/pointers/node_ref.rs
@@ -479,10 +479,10 @@ impl_all_derefs_for_node_ref!(
 impl<K: BTreeKey + ?Sized, V: BTreeValue + ?Sized>
     SharedNodeRef<K, V, marker::Unlocked, marker::Leaf>
 {
-    pub fn lock_exclusive_jittered(
+    pub fn lock_exclusive_with_backoff(
         self,
     ) -> SharedNodeRef<K, V, marker::LockedExclusive, marker::Leaf> {
-        self.header().lock_exclusive_jittered();
+        self.header().lock_exclusive_with_backoff();
         SharedNodeRef {
             node: ManuallyDrop::new(self.into_ptr()),
             lock_info: LockInfo::exclusive(),
@@ -490,10 +490,10 @@ impl<K: BTreeKey + ?Sized, V: BTreeValue + ?Sized>
         }
     }
 
-    pub fn lock_exclusive_if_not_retired_jittered(
+    pub fn lock_exclusive_if_not_retired_with_backoff(
         self,
     ) -> Result<SharedNodeRef<K, V, marker::LockedExclusive, marker::Leaf>, LockError> {
-        self.header().lock_exclusive_if_not_retired_jittered()?;
+        self.header().lock_exclusive_if_not_retired_with_backoff()?;
         Ok(SharedNodeRef {
             node: ManuallyDrop::new(self.into_ptr()),
             lock_info: LockInfo::exclusive(),
@@ -506,10 +506,10 @@ impl<K: BTreeKey + ?Sized, V: BTreeValue + ?Sized>
     OwnedNodeRef<K, V, marker::Unlocked, marker::Leaf>
 {
     #[allow(dead_code)]
-    pub fn lock_exclusive_jittered(
+    pub fn lock_exclusive_with_backoff(
         self,
     ) -> OwnedNodeRef<K, V, marker::LockedExclusive, marker::Leaf> {
-        self.header().lock_exclusive_jittered();
+        self.header().lock_exclusive_with_backoff();
         OwnedNodeRef {
             node: ManuallyDrop::new(self.into_ptr()),
             lock_info: LockInfo::exclusive(),

--- a/btree/src/search.rs
+++ b/btree/src/search.rs
@@ -175,7 +175,7 @@ fn get_leaf_exclusively_using_optimistic_search<
     do_optimistic_search(
         root,
         |node| SharedNodeRef::from_unknown_node_ptr(node.find_child(search_key)).assume_unlocked(),
-        |node| node.lock_exclusive_if_not_retired_jittered(),
+        |node| node.lock_exclusive_if_not_retired_with_backoff(),
         |node| node.unlock_exclusive(),
     )
 }
@@ -191,7 +191,7 @@ fn get_leaf_exclusively_using_shared_search<
     do_shared_search(
         root,
         |node| SharedNodeRef::from_unknown_node_ptr(node.find_child(search_key)).assume_unlocked(),
-        |node| node.lock_exclusive_jittered(),
+        |node| node.lock_exclusive_with_backoff(),
     )
 }
 
@@ -226,7 +226,7 @@ pub fn get_leaf_exclusively_using_exclusive_search<
     let top_of_tree = if top_of_tree.is_leaf() {
         top_of_tree
             .assert_leaf()
-            .lock_exclusive_jittered()
+            .lock_exclusive_with_backoff()
             .erase_node_type()
     } else {
         top_of_tree.lock_exclusive()
@@ -264,7 +264,7 @@ pub fn get_leaf_exclusively_using_exclusive_search<
         let found_child = if found_child.is_leaf() {
             found_child
                 .assert_leaf()
-                .lock_exclusive_jittered()
+                .lock_exclusive_with_backoff()
                 .erase_node_type()
         } else {
             found_child.lock_exclusive()
@@ -301,7 +301,7 @@ pub fn get_first_leaf_exclusively_using_optimistic_search<
     do_optimistic_search(
         root,
         |node| SharedNodeRef::from_unknown_node_ptr(node.get_first_child()).assume_unlocked(),
-        |node| node.lock_exclusive_if_not_retired_jittered(),
+        |node| node.lock_exclusive_if_not_retired_with_backoff(),
         |node| node.unlock_exclusive(),
     )
 }
@@ -315,7 +315,7 @@ pub fn get_first_leaf_exclusively_using_shared_search<
     do_shared_search(
         root,
         |node| SharedNodeRef::from_unknown_node_ptr(node.get_first_child()).assume_unlocked(),
-        |node| node.lock_exclusive_jittered(),
+        |node| node.lock_exclusive_with_backoff(),
     )
 }
 
@@ -328,7 +328,7 @@ pub fn get_last_leaf_exclusively_using_optimistic_search<
     do_optimistic_search(
         root,
         |node| SharedNodeRef::from_unknown_node_ptr(node.get_last_child()).assume_unlocked(),
-        |node| node.lock_exclusive_if_not_retired_jittered(),
+        |node| node.lock_exclusive_if_not_retired_with_backoff(),
         |node| node.unlock_exclusive(),
     )
 }
@@ -342,6 +342,6 @@ pub fn get_last_leaf_exclusively_using_shared_search<
     do_shared_search(
         root,
         |node| SharedNodeRef::from_unknown_node_ptr(node.get_last_child()).assume_unlocked(),
-        |node| node.lock_exclusive_jittered(),
+        |node| node.lock_exclusive_with_backoff(),
     )
 }

--- a/btree/src/splitting.rs
+++ b/btree/src/splitting.rs
@@ -81,7 +81,7 @@ where
     // update sibling pointers
     if let Some(next_leaf) = left_leaf.next_leaf() {
         // if we have a right sibling, it's new sibling is right_leaf
-        let next_leaf = next_leaf.lock_exclusive_jittered();
+        let next_leaf = next_leaf.lock_exclusive_with_backoff();
         right_leaf
             .next_leaf
             .store(next_leaf.as_shared_leaf_ptr(), Ordering::Release);


### PR DESCRIPTION
Renames jittered lock methods to use `with_backoff` naming convention for clarity