### PR TITLE
Add QsAtomic lock-free single-writer cell

### DIFF
--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -35,7 +35,7 @@ mod tree;
 mod util;
 pub use cursor::{Cursor, CursorMut, NonLockingCursor};
 pub use iter::{BackwardBTreeIterator, ForwardBTreeIterator};
-pub use pointers::OwnedThinAtomicPtr;
+pub use pointers::{OwnedThinAtomicPtr, QsAtomic};
 pub use qsbr::{qsbr_reclaimer, MemoryReclaimer};
 pub use reference::{Entry, Ref};
 pub use tree::{

--- a/btree/src/pointers.rs
+++ b/btree/src/pointers.rs
@@ -1,11 +1,13 @@
 pub mod arc;
 pub mod atomic;
 pub mod node_ref;
+pub mod qs_atomic;
 pub mod traits;
 
 pub use self::{
     arc::OwnedAtomicThinArc,
     atomic::OwnedThinAtomicPtr,
     node_ref::{marker, OwnedNodeRef, SharedDiscriminatedNode, SharedNodeRef},
+    qs_atomic::QsAtomic,
     traits::AtomicPointerArrayValue,
 };

--- a/btree/src/pointers/atomic.rs
+++ b/btree/src/pointers/atomic.rs
@@ -94,7 +94,7 @@ impl<T: ?Sized + Pointable + Send + 'static> OwnedThinAtomicPtr<T> {
     }
 }
 
-impl<T: Sized + Pointable + Send + 'static> OwnedThinAtomicPtr<T> {
+impl<T: ?Sized + Pointable + Send + 'static> OwnedThinAtomicPtr<T> {
     pub fn new(ptr: QsOwned<T>) -> Self {
         Self {
             ptr: AtomicPtr::new(ptr.into_ptr()),

--- a/btree/src/pointers/qs_atomic.rs
+++ b/btree/src/pointers/qs_atomic.rs
@@ -5,38 +5,90 @@ use crate::sync::Ordering;
 
 /// Lock-free atomic cell that reclaims replaced values via QSBR.
 /// Writers are single-writer and must serialize themselves.
-pub struct QsAtomic<T: Pointable> {
+pub struct QsAtomic<T: ?Sized + Pointable> {
     slot: OwnedThinAtomicPtr<T>,
 }
 
-impl<T: Pointable> QsAtomic<T> {
+impl<T: Pointable + Send + 'static> QsAtomic<T> {
     pub fn new(value: T) -> Self {
         Self {
             slot: OwnedThinAtomicPtr::new(QsOwned::new(value)),
         }
     }
 
+    /// Atomically replaces the stored value, returning the previous one.
+    ///
+    /// Dropping the returned `QsOwned` (or `let _ = atom.swap(...)`) schedules
+    /// QSBR reclamation; keep it alive if you need to inspect the old value
+    /// before it's reclaimed.
     #[inline]
-    pub fn load(&self) -> QsShared<T> {
+    pub fn swap(&self, value: T, order: Ordering) -> QsOwned<T> {
         self.slot
-            .load_shared(Ordering::Acquire)
+            .swap(QsOwned::new(value), order)
             .expect("QsAtomic is always populated")
-    }
-
-    /// Single-writer only: concurrent calls from multiple threads race the
-    /// load/swap and can leak or double-publish. This is load/compute/swap,
-    /// not a CAS loop.
-    #[inline]
-    pub fn update_with(&self, f: impl FnOnce(&T) -> T) {
-        let next = f(&self.load());
-        let _old = self.slot.swap(QsOwned::new(next), Ordering::AcqRel);
     }
 }
 
-impl<T: Pointable> Drop for QsAtomic<T> {
+impl<T: Send + 'static + Clone> QsAtomic<[T]> {
+    pub fn new_from_slice(init: &[T]) -> Self {
+        Self {
+            slot: OwnedThinAtomicPtr::new(QsOwned::new_from_slice(init)),
+        }
+    }
+
+    /// Atomically replaces the stored value, returning the previous one.
+    ///
+    /// Dropping the returned `QsOwned` (or `let _ = atom.swap(...)`) schedules
+    /// QSBR reclamation; keep it alive if you need to inspect the old value
+    /// before it's reclaimed.
+    #[inline]
+    pub fn swap_from_slice(&self, value: &[T], order: Ordering) -> QsOwned<[T]> {
+        self.slot
+            .swap(QsOwned::new_from_slice(value), order)
+            .expect("QsAtomic is always populated")
+    }
+}
+
+impl QsAtomic<str> {
+    pub fn new_from_str(init: &str) -> Self {
+        Self {
+            slot: OwnedThinAtomicPtr::new(QsOwned::new_from_str(init)),
+        }
+    }
+
+    /// Atomically replaces the stored value, returning the previous one.
+    ///
+    /// Dropping the returned `QsOwned` (or `let _ = atom.swap(...)`) schedules
+    /// QSBR reclamation; keep it alive if you need to inspect the old value
+    /// before it's reclaimed.
+    #[inline]
+    pub fn swap_from_str(&self, value: &str, order: Ordering) -> QsOwned<str> {
+        self.slot
+            .swap(QsOwned::new_from_str(value), order)
+            .expect("QsAtomic is always populated")
+    }
+}
+
+impl<T: ?Sized + Pointable + Send + 'static> QsAtomic<T> {
+    #[inline]
+    pub fn load(&self, order: Ordering) -> QsShared<T> {
+        self.slot
+            .load_shared(order)
+            .expect("QsAtomic is always populated")
+    }
+}
+
+impl<T: ?Sized + Pointable + Send + 'static> Drop for QsAtomic<T> {
     fn drop(&mut self) {
-        // SAFETY: `&mut self` rules out concurrent writers; we take ownership
-        // exactly once and let the resulting `QsOwned` schedule QSBR reclamation.
+        // SAFETY: `&mut self` rules out concurrent writers, so we can take
+        // ownership of the slot exactly once and let the resulting `QsOwned`
+        // schedule QSBR reclamation.
+        //
+        // Ordering: Drop is a pure load, so the only thing that matters is
+        // what it pairs with. If the last writer used `Release`/`AcqRel`/
+        // `SeqCst` on `swap`, our `Acquire` pairs with the Release on its
+        // store side and establishes happens-before through the atomic
+        // itself.
         let _owned = unsafe {
             self.slot
                 .load_owned(Ordering::Acquire)
@@ -53,27 +105,37 @@ mod tests {
     #[qsbr_test]
     fn test_load_returns_initial_value() {
         let atom = QsAtomic::new(42usize);
-        assert_eq!(*atom.load(), 42);
+        assert_eq!(*atom.load(Ordering::Acquire), 42);
     }
 
     #[qsbr_test]
-    fn test_update_with_publishes_new_value() {
+    fn test_swap_publishes_new_value() {
         let atom = QsAtomic::new(10usize);
 
-        atom.update_with(|current| current + 1);
-        assert_eq!(*atom.load(), 11);
+        let next = *atom.load(Ordering::Acquire) + 1;
+        let _old = atom.swap(next, Ordering::AcqRel);
+        assert_eq!(*atom.load(Ordering::Acquire), 11);
 
-        atom.update_with(|current| current * 2);
-        assert_eq!(*atom.load(), 22);
+        let next = *atom.load(Ordering::Acquire) * 2;
+        let _old = atom.swap(next, Ordering::AcqRel);
+        assert_eq!(*atom.load(Ordering::Acquire), 22);
     }
 
     #[qsbr_test]
-    fn test_prior_loads_stay_valid_across_update() {
-        let atom = QsAtomic::new(100usize);
-        let before = atom.load();
+    fn test_swap_returns_previous_value() {
+        let atom = QsAtomic::new(10usize);
+        let old = atom.swap(20, Ordering::AcqRel);
+        assert_eq!(*old, 10);
+        assert_eq!(*atom.load(Ordering::Acquire), 20);
+    }
 
-        atom.update_with(|_| 200);
-        let after = atom.load();
+    #[qsbr_test]
+    fn test_prior_loads_stay_valid_across_swap() {
+        let atom = QsAtomic::new(100usize);
+        let before = atom.load(Ordering::Acquire);
+
+        let _old = atom.swap(200, Ordering::AcqRel);
+        let after = atom.load(Ordering::Acquire);
 
         assert_eq!(*before, 100);
         assert_eq!(*after, 200);
@@ -82,7 +144,35 @@ mod tests {
     #[qsbr_test]
     fn test_drop_does_not_leak_or_panic() {
         let atom = QsAtomic::new(vec![1u32, 2, 3]);
-        assert_eq!(atom.load().len(), 3);
+        assert_eq!(atom.load(Ordering::Acquire).len(), 3);
         drop(atom);
+    }
+
+    #[qsbr_test]
+    fn test_new_from_str() {
+        let atom: QsAtomic<str> = QsAtomic::new_from_str("hello");
+        assert_eq!(&*atom.load(Ordering::Acquire), "hello");
+    }
+
+    #[qsbr_test]
+    fn test_new_from_slice() {
+        let atom: QsAtomic<[u32]> = QsAtomic::new_from_slice(&[1u32, 2, 3]);
+        assert_eq!(&*atom.load(Ordering::Acquire), [1u32, 2, 3].as_slice());
+    }
+
+    #[qsbr_test]
+    fn test_swap_from_str() {
+        let atom: QsAtomic<str> = QsAtomic::new_from_str("hello");
+        let old = atom.swap_from_str("world", Ordering::AcqRel);
+        assert_eq!(&*old, "hello");
+        assert_eq!(&*atom.load(Ordering::Acquire), "world");
+    }
+
+    #[qsbr_test]
+    fn test_swap_from_slice() {
+        let atom: QsAtomic<[u32]> = QsAtomic::new_from_slice(&[1u32, 2, 3]);
+        let old = atom.swap_from_slice(&[4u32, 5], Ordering::AcqRel);
+        assert_eq!(&*old, [1u32, 2, 3].as_slice());
+        assert_eq!(&*atom.load(Ordering::Acquire), [4u32, 5].as_slice());
     }
 }

--- a/btree/src/pointers/qs_atomic.rs
+++ b/btree/src/pointers/qs_atomic.rs
@@ -1,0 +1,88 @@
+use thin::{Pointable, QsOwned, QsShared};
+
+use super::OwnedThinAtomicPtr;
+use crate::sync::Ordering;
+
+/// Lock-free atomic cell that reclaims replaced values via QSBR.
+/// Writers are single-writer and must serialize themselves.
+pub struct QsAtomic<T: Pointable> {
+    slot: OwnedThinAtomicPtr<T>,
+}
+
+impl<T: Pointable> QsAtomic<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            slot: OwnedThinAtomicPtr::new(QsOwned::new(value)),
+        }
+    }
+
+    #[inline]
+    pub fn load(&self) -> QsShared<T> {
+        self.slot
+            .load_shared(Ordering::Acquire)
+            .expect("QsAtomic is always populated")
+    }
+
+    /// Single-writer only: concurrent calls from multiple threads race the
+    /// load/swap and can leak or double-publish. This is load/compute/swap,
+    /// not a CAS loop.
+    #[inline]
+    pub fn update_with(&self, f: impl FnOnce(&T) -> T) {
+        let next = f(&self.load());
+        let _old = self.slot.swap(QsOwned::new(next), Ordering::AcqRel);
+    }
+}
+
+impl<T: Pointable> Drop for QsAtomic<T> {
+    fn drop(&mut self) {
+        // SAFETY: `&mut self` rules out concurrent writers; we take ownership
+        // exactly once and let the resulting `QsOwned` schedule QSBR reclamation.
+        let _owned = unsafe {
+            self.slot
+                .load_owned(Ordering::Acquire)
+                .expect("QsAtomic is always populated")
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use btree_macros::qsbr_test;
+
+    #[qsbr_test]
+    fn test_load_returns_initial_value() {
+        let atom = QsAtomic::new(42usize);
+        assert_eq!(*atom.load(), 42);
+    }
+
+    #[qsbr_test]
+    fn test_update_with_publishes_new_value() {
+        let atom = QsAtomic::new(10usize);
+
+        atom.update_with(|current| current + 1);
+        assert_eq!(*atom.load(), 11);
+
+        atom.update_with(|current| current * 2);
+        assert_eq!(*atom.load(), 22);
+    }
+
+    #[qsbr_test]
+    fn test_prior_loads_stay_valid_across_update() {
+        let atom = QsAtomic::new(100usize);
+        let before = atom.load();
+
+        atom.update_with(|_| 200);
+        let after = atom.load();
+
+        assert_eq!(*before, 100);
+        assert_eq!(*after, 200);
+    }
+
+    #[qsbr_test]
+    fn test_drop_does_not_leak_or_panic() {
+        let atom = QsAtomic::new(vec![1u32, 2, 3]);
+        assert_eq!(atom.load().len(), 3);
+        drop(atom);
+    }
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,7 @@ MIRIFLAGS=-Zmiri-tree-borrows cargo +nightly miri test -p qsbr
 MIRIFLAGS=-Zmiri-tree-borrows cargo +nightly miri test -p thin
 MIRIFLAGS=-Zmiri-tree-borrows cargo +nightly miri test -p btree -- \
   pointers::atomic::tests \
+  pointers::qs_atomic::tests \
   cursor::tests::test_interaction_between_mut_cursor_and_non_locking_cursor \
   cursor::tests::test_interaction_between_mut_cursor_and_shared_cursor \
   tree::tests::test_random_inserts_gets_and_removes_with_seed_multi_threaded \


### PR DESCRIPTION
## Summary

Adds the simple helper `QsAtomic<T>`, a lock-free single-writer atomic cell that wraps `OwnedThinAtomicPtr` and defers reclamation of replaced values via QSBR. 

# Test plan

- New unit tests.